### PR TITLE
Ability to use sNp files for T Connector Model

### DIFF
--- a/ADI_model/.gitignore
+++ b/ADI_model/.gitignore
@@ -1,5 +1,6 @@
 #ADI Model Specific Ignores
 data/
+tmp_vectorfit/
 gif/
 zcable*
 cable.p

--- a/ADI_model/Pipfile
+++ b/ADI_model/Pipfile
@@ -8,6 +8,7 @@ numpy = "*"
 matplotlib = "*"
 imageio = "*"
 scipy = "*"
+scikit-rf = ">=0.24"
 
 [dev-packages]
 

--- a/ADI_model/cmodel.py
+++ b/ADI_model/cmodel.py
@@ -41,7 +41,7 @@ from node import Node as Node
 from termination import Termination as Termination
 from transmitter import Transmitter as Transmitter
 from trunk import Trunk as Trunk
-from t_connector import T_connector, TouchstoneT_Connector
+from t_connector import T_connector, TouchstoneT_Connector, AbstractT_Connector
 from dme import dme_transmitter as dme_transmitter
 from dme import eye_diagram 
 from dme import dme_receiver
@@ -652,24 +652,13 @@ if __name__ == '__main__':
     while(trunk_temp):
         port = "y%d" % node_iter
         #see if there is a unique node description in the json data
-
-        if config["tee"]["touchstone"]:
-            tee = TouchstoneT_Connector(
-                config["tee"]
-                , number=node_iter
-                , port1=mixing_segment[-1].port2
-                , port2=trunk_temp[0].port1
-                , node_port=port
-                )
-        else:
-            tee = T_connector(
-                    number=node_iter
-                    , port1=mixing_segment[-1].port2
-                    , port2=trunk_temp[0].port1
-                    , node_port=port
-                    , lcomp       = config['node_descriptions'][node_iter]['lcomp']
-                    , lcomp_match = config['node_descriptions'][node_iter]['lcomp_match']
-                    )
+        tee = AbstractT_Connector.get(
+            number=node_iter, 
+            port1=mixing_segment[-1].port2, 
+            port2=trunk_temp[0].port1,
+            node_port=port,
+            config=config
+            )
 
         node_iter+=1
         #put a t-connector on the mixing segment
@@ -687,22 +676,15 @@ if __name__ == '__main__':
     #print("cond2: %s" % cond2)
     if( cond1 or cond2 ):
         port = "y%d" % node_iter
-        if config["tee"]["touchstone"]:
-            tee = TouchstoneT_Connector(
-                config["tee"]
-                , number=node_iter
-                , port1=mixing_segment[-1].port2
-                , port2="end"
-                , node_port=port
-                )
-        else:
-            tee = T_connector(
-                    number=node_iter
-                    ,port1=mixing_segment[-1].port2
-                    ,port2="end"
-                    ,node_port=port
-                    ,lcomp=config['node_descriptions'][node_iter]['lcomp']
-                    )
+
+        tee = AbstractT_Connector.get(
+            number=node_iter, 
+            port1=mixing_segment[-1].port2, 
+            port2="end",
+            node_port=port,
+            config=config
+            )
+
         node_iter+=1
         mixing_segment.append(tee)
  

--- a/ADI_model/cmodel.py
+++ b/ADI_model/cmodel.py
@@ -41,7 +41,7 @@ from node import Node as Node
 from termination import Termination as Termination
 from transmitter import Transmitter as Transmitter
 from trunk import Trunk as Trunk
-from t_connector import T_connector as T_connector
+from t_connector import T_connector, TouchstoneT_Connector
 from dme import dme_transmitter as dme_transmitter
 from dme import eye_diagram 
 from dme import dme_receiver
@@ -652,14 +652,25 @@ if __name__ == '__main__':
     while(trunk_temp):
         port = "y%d" % node_iter
         #see if there is a unique node description in the json data
-        tee = T_connector(
-                number=node_iter
+
+        if config["tee"]["touchstone"]:
+            tee = TouchstoneT_Connector(
+                config["tee"]
+                , number=node_iter
                 , port1=mixing_segment[-1].port2
                 , port2=trunk_temp[0].port1
                 , node_port=port
-                , lcomp       = config['node_descriptions'][node_iter]['lcomp']
-                , lcomp_match = config['node_descriptions'][node_iter]['lcomp_match']
                 )
+        else:
+            tee = T_connector(
+                    number=node_iter
+                    , port1=mixing_segment[-1].port2
+                    , port2=trunk_temp[0].port1
+                    , node_port=port
+                    , lcomp       = config['node_descriptions'][node_iter]['lcomp']
+                    , lcomp_match = config['node_descriptions'][node_iter]['lcomp_match']
+                    )
+
         node_iter+=1
         #put a t-connector on the mixing segment
         mixing_segment.append(tee)
@@ -676,13 +687,22 @@ if __name__ == '__main__':
     #print("cond2: %s" % cond2)
     if( cond1 or cond2 ):
         port = "y%d" % node_iter
-        tee = T_connector(
-                number=node_iter
-                ,port1=mixing_segment[-1].port2
-                ,port2="end"
-                ,node_port=port
-                ,lcomp=config['node_descriptions'][node_iter]['lcomp']
+        if config["tee"]["touchstone"]:
+            tee = TouchstoneT_Connector(
+                config["tee"]
+                , number=node_iter
+                , port1=mixing_segment[-1].port2
+                , port2="end"
+                , node_port=port
                 )
+        else:
+            tee = T_connector(
+                    number=node_iter
+                    ,port1=mixing_segment[-1].port2
+                    ,port2="end"
+                    ,node_port=port
+                    ,lcomp=config['node_descriptions'][node_iter]['lcomp']
+                    )
         node_iter+=1
         mixing_segment.append(tee)
  

--- a/ADI_model/cmodel.py
+++ b/ADI_model/cmodel.py
@@ -5,14 +5,12 @@
 #The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 #THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-import re
 import sys
 from os import listdir
 from os.path import dirname
 import os.path 
 import shutil
 import argparse
-import time
 import random
 import numpy as np
 #from scipy.signal import butter, lfilter, freqz
@@ -41,9 +39,8 @@ from node import Node as Node
 from termination import Termination as Termination
 from transmitter import Transmitter as Transmitter
 from trunk import Trunk as Trunk
-from t_connector import T_connector, TouchstoneT_Connector, AbstractT_Connector
+from t_connector import AbstractT_Connector
 from dme import dme_transmitter as dme_transmitter
-from dme import eye_diagram 
 from dme import dme_receiver
 
 def _readTxt(infile):

--- a/ADI_model/defaults.json
+++ b/ADI_model/defaults.json
@@ -108,6 +108,12 @@
     "node_descriptions" : [],
     "trunk_description" : {
         "segments" : []
+    },
+    "tee": {
+        "touchstone": null,
+        "fitting_error_rms": 0.01,
+        "port_order": [1,2,3,4,5,6],
+        "fitted_model_name": "touchstone_tee"
     }
 
 }

--- a/ADI_model/description.json
+++ b/ADI_model/description.json
@@ -16,7 +16,7 @@
     "seed" : "Specify a seed number for the random number generator.  Set to -1 for a random seed",
     "tx_node" : "Specify the node number to treat as the transmitting node",
     "attach_error" : "add gaussian error to attachment points.  Pass the the sigma value of the attachment error or 0 for no error.  Ignored for randomly placed nodes.  If 'attach_error' is set to a large value, can separation_min be violated? I don't know",
-    "attach_points" : "if a list of values is specified, other 
+    "attach_points" : "if a list of values is specified, other", 
     "noautoscale" : true,
     "noplot" : false,
     "plot_png_filename" : "zcable.png",
@@ -74,6 +74,13 @@
     "node_descriptions" : [],
     "trunk_description" : {
         "segments" : []
+    
+    },
+    "tee": {
+        "touchstone": "Path to touchstone file",
+        "fitting_error_rms": "Maximum acceptable fitting error, fitting is done by scikit-rf VectorFitting class.",
+        "port_order": "Port order for the touchstone file. Default [1,2,3,4,5,6] which translates to [in_p, in_n, out_p, out_n, node_p, node_n]",
+        "fitted_model_name": "A verbose name to identify the touchstone file"
     }
 
 }

--- a/ADI_model/dme.py
+++ b/ADI_model/dme.py
@@ -153,7 +153,7 @@ class analog_filter_s_domain(object):
             return fft
 
         Wcutoff = (2*math.pi*self.cutoff)
-        filtered = np.ones_like(fft,dtype=np.complex)
+        filtered = np.ones_like(fft,dtype=complex)
         for i,freq in enumerate(fft_freq):
             if(freq == 0):
                 filtered[i] = complex(1e-30,0)
@@ -172,7 +172,7 @@ class analog_filter_s_domain(object):
             return fft
 
         Wcutoff = (2*math.pi*self.cutoff)
-        filtered = np.ones_like(fft, dtype=np.complex)
+        filtered = np.ones_like(fft, dtype=complex)
         for i,freq in enumerate(fft_freq):
                 w = freq * (2*math.pi)
                 h=complex(1,0)
@@ -209,7 +209,7 @@ class dme_signal(object):
 
     def add_filter(self,filter_type="lpf",cutoff=20e6,order=1):
         if(len(self.filter)==0):
-            self.filter = np.ones_like(self.fft_freq,dtype=np.complex)
+            self.filter = np.ones_like(self.fft_freq,dtype=complex)
             print("#Creating Filter Container")
         self.filters.append(analog_filter_s_domain(filter_type, cutoff, order))
         self.filter = self.filters[-1].filter_fft(self.fft_freq, self.filter)
@@ -311,10 +311,10 @@ class dme_signal(object):
 
 
     def get_filtered_fft(self):
-        #self.filter = np.ones_like(self.fft_freq,dtype=np.complex)
+        #self.filter = np.ones_like(self.fft_freq,dtype=complex)
         #for f in self.filters:
         #    self.filter = f.filter_fft(self.fft_freq, self.filter)
-        self.fft_filtered = np.ones_like(self.fft_freq,dtype=np.complex)
+        self.fft_filtered = np.ones_like(self.fft_freq,dtype=complex)
         for i in range(self.filter.size):
             self.fft_filtered[i] = self.fft_value[i] * self.filter[i]
         return self.fft_filtered
@@ -417,7 +417,7 @@ class dme_transmitter(dme_signal):
         self.tstop=ts*ns 
 
         self._generateRandomBits()
-        self.filter = np.ones_like(self.fft_freq,dtype=np.complex)
+        self.filter = np.ones_like(self.fft_freq,dtype=complex)
 
     def _generateRandomBits(self):
         self.pattern = np.random.randint(2,size=self.n_symbols)
@@ -492,7 +492,7 @@ class dme_receiver(dme_signal):
         self.imgDir = imgDir #directory for graph outputs
 
         self.fft_freq = dme_transmitter.fft_freq
-        self.filter = np.ones_like(self.fft_freq,dtype=np.complex)
+        self.filter = np.ones_like(self.fft_freq,dtype=complex)
         self.t_domain_mdi      = None
         self.t_domain_filtered = None
 

--- a/ADI_model/t_connector.py
+++ b/ADI_model/t_connector.py
@@ -5,17 +5,9 @@
 #The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 #THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-import re
-import sys
-from os import listdir
-from os.path import dirname
-import os.path 
-import shutil
-import argparse
-import time
-import random
-import numpy as np
-import math
+from typing import List
+
+from touchstone_fit import TouchstoneFit
 
 class T_connector(object):
     """Object representing a mixing segment trunk termination
@@ -79,6 +71,22 @@ class T_connector(object):
                     self.node_port, self.node_port,
                     self.name
                 )
+
+
+class TouchstoneT_Connector(TouchstoneFit):
+    n_ports = 6
+
+    def __init__(self, config: dict, number: int, port1: str, port2: str, node_port: str):
+        super().__init__(config["touchstone"],config["fitted_model_name"], config["fitting_error_rms"], f"tee{number}", config["port_order"])
+
+        self.port1 = port1
+        self.port2 = port2
+        self.node_port = node_port
+
+    @property
+    def port_names(self) -> List[str]:
+        return [self.port1, self.port1, self.port2, self.port2, self.node_port, self.node_port]
+
 
 if __name__ == '__main__':
     t0 = Termination(name="t0",port="t0", stim_port="ts")

--- a/ADI_model/t_connector.py
+++ b/ADI_model/t_connector.py
@@ -77,7 +77,21 @@ class TouchstoneT_Connector(TouchstoneFit):
     n_ports = 6
 
     def __init__(self, config: dict, number: int, port1: str, port2: str, node_port: str):
-        super().__init__(config["touchstone"],config["fitted_model_name"], config["fitting_error_rms"], f"tee{number}", config["port_order"])
+        """Create a T Connector from Touchstone data
+
+        Args:
+            config: Configuration dictionary loaded from json
+            number: Index of the T Connector
+            port1: Trunk Input Port name
+            port2: Trunk Output Port name
+            node_port: Node Port name
+        """
+        super().__init__(
+            config["touchstone"],
+            config["fitted_model_name"], 
+            config["fitting_error_rms"], 
+            f"tee{number}", 
+            config["port_order"])
 
         self.port1 = port1
         self.port2 = port2
@@ -85,6 +99,11 @@ class TouchstoneT_Connector(TouchstoneFit):
 
     @property
     def port_names(self) -> List[str]:
+        """Get the list of Port names
+
+        Returns:
+            list of Port names 
+        """
         return [self.port1, self.port1, self.port2, self.port2, self.node_port, self.node_port]
 
 

--- a/ADI_model/touchstone_fit.py
+++ b/ADI_model/touchstone_fit.py
@@ -1,0 +1,97 @@
+from typing import List
+
+from abc import ABC, abstractproperty
+import os
+
+import skrf as rf
+
+vectorfit_cache = {}
+
+
+class FittedTouchstone(ABC):
+    n_ports = 0
+
+    def __init__(
+        self,
+        touchstone_file: str,
+        fittedModelName: str,
+        fitting_error: float,
+        instance_name: str = "",
+        port_order: List[int] = None,
+        max_poles: int = 30,
+    ):
+
+        self.instance_name = instance_name
+        self.port_order = port_order if port_order else list(range(self.n_ports))
+
+        netw = rf.Network(touchstone_file)
+        assert (
+            netw.nports == self.n_ports
+        ), f"{self.__class__.__name__} needs exactly {self.n_ports} ports, got: {netw.nports}"
+        assert (
+            len(self.port_order) == self.n_ports
+        ), f"port_order has to be of length {self.n_ports} or None"
+
+        key = (touchstone_file, fittedModelName, fitting_error)
+
+        if instance_name:
+            self.instance_name = instance_name
+        else:
+            self.instance_name = f"fitted_{str(hash(key))}"
+
+        cached = False
+        if key not in vectorfit_cache.keys():
+            vf = rf.VectorFitting(netw)
+
+            poles = 4
+            while True:
+                print(f"Fit with {poles} poles")
+                if poles > max_poles:
+                    raise RuntimeError("Unable to fit network ")
+                vf.vector_fit(n_poles_real=0, n_poles_cmplx=poles)
+                error = vf.get_rms_error()
+                if error < fitting_error:
+                    print(f"Fitting Error RMS", error)
+                    break
+                poles += 2
+
+            vectorfit_cache[key] = vf
+        else:
+            cached = True
+            vf = vectorfit_cache[key]
+
+        spice_file = f"fitted_{instance_name}_{fittedModelName}_{str(hash(key))}.sp"
+        vf.write_spice_subcircuit_s(spice_file, self.instance_name)
+        self.inner_circuit = open(spice_file).read()
+
+        if cached:
+            os.remove(spice_file)
+
+    @abstractproperty
+    def port_names(self) -> List[str]:
+        pass
+
+    def __str__(self) -> str:
+        s = [
+            "**********************",
+            "* Fitted Touchstone",
+            "* name        %s" % self.instance_name,
+            "**********************",
+        ]
+        return "\n".join(s)
+
+    def subcircuit(self) -> str:
+        return self.inner_circuit
+
+    def instance(self) -> str:
+        port_tpl = list(zip(self.port_order, self.port_names))
+
+        port_tpl.sort()
+        ports = [e[1] for e in port_tpl]
+
+        """Generate the instance call for this cable segment"""
+        return "x%s %sp %sn %sp %sn %sp %sn %s" % (
+            self.instance_name,
+            *ports,
+            self.instance_name,
+        )

--- a/ADI_model/touchstone_fit.py
+++ b/ADI_model/touchstone_fit.py
@@ -10,6 +10,7 @@ from typing import List
 
 from abc import ABC, abstractproperty
 import os
+from pathlib import Path
 
 import skrf as rf
 
@@ -68,7 +69,9 @@ class TouchstoneFit(ABC):
             cached = True
             vf = vectorfit_cache[key]
 
-        spice_file = f"fitted_{instance_name}_{fittedModelName}_{str(hash(key))}.sp"
+        spice_file = Path("tmp_vectorfit") / f"fitted_{instance_name}_{fittedModelName}_{str(hash(key))}.sp"
+        spice_file.parent.mkdir(exist_ok=True)
+
         vf.write_spice_subcircuit_s(spice_file, self.instance_name)
         self.inner_circuit = open(spice_file).read()
 

--- a/ADI_model/touchstone_fit.py
+++ b/ADI_model/touchstone_fit.py
@@ -56,12 +56,12 @@ class TouchstoneFit(ABC):
                 print(f"Fit with {poles} poles")
                 if poles > max_poles:
                     raise RuntimeError("Unable to fit network ")
-                vf.vector_fit(n_poles_real=0, n_poles_cmplx=poles)
+                vf.vector_fit(n_poles_real=1, n_poles_cmplx=poles)
                 error = vf.get_rms_error()
                 if error < fitting_error:
                     print(f"Fitting Error RMS", error)
                     break
-                poles += 2
+                poles += 1
 
             vectorfit_cache[key] = vf
         else:

--- a/ADI_model/touchstone_fit.py
+++ b/ADI_model/touchstone_fit.py
@@ -1,3 +1,11 @@
+#Copyright 2022 Rosenberger Hochfreqenztechnik GmbH & Co. KG
+#Author: Franz Forstmayr
+# 
+#Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+#The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+#THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
 from typing import List
 
 from abc import ABC, abstractproperty
@@ -8,7 +16,7 @@ import skrf as rf
 vectorfit_cache = {}
 
 
-class FittedTouchstone(ABC):
+class TouchstoneFit(ABC):
     n_ports = 0
 
     def __init__(

--- a/ADI_model/touchstone_fit.py
+++ b/ADI_model/touchstone_fit.py
@@ -97,21 +97,27 @@ class TouchstoneFit(ABC):
 
         fitted_netw = rf.Network(frequency=original.frequency, s=fitted_s, name="fitted")
 
-        fig, ax = plt.subplots(2, 2)
-        fig.set_size_inches(12, 8)
-        
-        for i in range(6):
-            current_ax = ax[0,0] if i < 4 else ax[0, 1]
-            self.plot_both_traces(original, fitted_netw, (i, i), current_ax)
+        with plt.style.context(os.path.join(rf.data.pwd, "skrf.mplstyle")):
+            fig, axes = plt.subplots(2, 2)
+            fig.set_size_inches(12, 8)
+            
+            axes[0,0].set_title("Return Loss Trunk")
+            axes[0,1].set_title("Return Loss Node")
+            for i in range(6):
+                current_ax = axes[0,0] if i < 4 else axes[0, 1]
+                self.plot_both_traces(original, fitted_netw, (i, i), current_ax)
 
-        for t0, t1 in [(1,5), (2,6), (3,5), (4,6)]:
-            self.plot_both_traces(original, fitted_netw, (t0-1, t1-1), ax[1,0])
+            axes[1,0].set_title("Insertion Loss Trunk - Node")
+            for t0, t1 in [(1,5), (2,6), (3,5), (4,6)]:
+                self.plot_both_traces(original, fitted_netw, (t0-1, t1-1), axes[1,0])
 
-        for t0, t1 in [(3,1), (4,2)]:
-            self.plot_both_traces(original, fitted_netw, (t0-1, t1-1), ax[1,1])
+            axes[1,1].set_title("Insertion Loss Trunk - Trunk")
+            for t0, t1 in [(3,1), (4,2)]:
+                self.plot_both_traces(original, fitted_netw, (t0-1, t1-1), axes[1,1])
 
-        file = self.spice_file.with_suffix('.png')
-        fig.savefig(file)
+            fig.tight_layout()
+            file = self.spice_file.with_suffix('.png')
+            fig.savefig(file)
 
 
 


### PR DESCRIPTION
This PR extends the ADI consensus model to use Touchstone data as model for the T Connectors.
The Touchstone model is fitted into a pole/zero model with the help of the [scikit-rf](https://github.com/scikit-rf/scikit-rf) library.

Be aware that this model uses a modification in `scikit-rf` which has been merged into the master branch but is not released yet, so if you want to try this code check out the latest `scikit-rf` version from github.

In some cases the vectorfit fails to converge, a Warning is displayed for this case.
If the fit is fine, graphs for comparison like the following are plotted.

![fitted_tee1_touchstone_tee_-1400814051539841986](https://user-images.githubusercontent.com/9936788/195122893-6cbb8796-7e5b-4317-b3d7-de3afa784e31.png)
